### PR TITLE
feat: improve QR scanner compatibility

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Depends
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 import database
@@ -8,6 +9,15 @@ import os
 import s3_client
 
 app = FastAPI()
+
+# Allow cross-origin requests during development
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 from api.v1 import abook as abook_v1
 from api.v1 import admin as admin_v1

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,3 @@
-VITE_API_BASE=http://localhost:8000
+# Base URL for API requests. Leave blank to use the frontend origin.
+VITE_API_BASE=
 VITE_LANGS=ca,es,en

--- a/frontend/public/locales/ca/translation.json
+++ b/frontend/public/locales/ca/translation.json
@@ -7,5 +7,6 @@
   "player_starts_at": "Comença a: {{seconds}} segons",
   "error_no_auth": "No s'han trobat dades d'autorització. Si us plau, escaneja un codi QR de nou.",
   "error_scanner": "Error amb l'escàner. Si us plau, comprova els permisos de la càmera.",
-  "error_auth_failed": "Error: Ha fallat l'autorització."
+  "error_auth_failed": "Error: Ha fallat l'autorització.",
+  "error_network": "Error de xarxa. Si us plau, torna-ho a provar."
 }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -7,5 +7,6 @@
   "player_starts_at": "Starts at: {{seconds}} seconds",
   "error_no_auth": "No authorization data found. Please scan a QR code again.",
   "error_scanner": "Error with the scanner. Please check camera permissions.",
-  "error_auth_failed": "Error: Failed to authorize."
+  "error_auth_failed": "Error: Failed to authorize.",
+  "error_network": "Network error. Please try again."
 }

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -7,5 +7,6 @@
   "player_starts_at": "Empieza en: {{seconds}} segundos",
   "error_no_auth": "No se encontraron datos de autorización. Por favor, escanea un código QR de nuevo.",
   "error_scanner": "Error con el escáner. Por favor, comprueba los permisos de la cámara.",
-  "error_auth_failed": "Error: Fallo al autorizar."
+  "error_auth_failed": "Error: Fallo al autorizar.",
+  "error_network": "Error de red. Por favor, inténtalo de nuevo."
 }

--- a/frontend/src/components/HLSPlayer.jsx
+++ b/frontend/src/components/HLSPlayer.jsx
@@ -8,9 +8,9 @@ const HLSPlayer = ({ src, title, author, qr, deviceId }) => {
   const syncProgress = async () => {
     if (!videoRef.current || !qr || !deviceId) return;
     const position = Math.round(videoRef.current.currentTime);
-    const apiUrl = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+    const apiBase = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '');
     try {
-      await axios.post(`${apiUrl}/api/v1/abook/${qr}/progress`, {
+      await axios.post(`${apiBase}/api/v1/abook/${qr}/progress`, {
         device_id: deviceId,
         position_sec: position,
       });

--- a/frontend/src/pages/ScannerPage.jsx
+++ b/frontend/src/pages/ScannerPage.jsx
@@ -1,23 +1,30 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useTranslation } from 'react-i18next';
 import { getDeviceId } from '../services/device';
-import { Html5Qrcode } from 'html5-qrcode';
+import { Html5Qrcode, Html5QrcodeSupportedFormats } from 'html5-qrcode';
 
 const qrcodeRegionId = "html5qr-code-full-region";
 
 const ScannerPage = () => {
   const { t } = useTranslation();
   const [error, setError] = useState('');
+  const [useNative, setUseNative] = useState(false);
   const navigate = useNavigate();
+  const videoRef = useRef(null);
+  const useNativeRef = useRef(false);
+  const streamRef = useRef(null);
+  const animationRef = useRef(null);
+  const html5QrCodeRef = useRef(null);
 
   const handleResult = useCallback(async (qrCode) => {
     setError('');
     try {
       const deviceId = await getDeviceId();
-      const apiUrl = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
-      const response = await axios.get(`${apiUrl}/api/v1/abook/${qrCode}/play-auth`, {
+      const apiBase = (import.meta.env.VITE_API_BASE || '').replace(/\/$/, '');
+      const url = `${apiBase}/api/v1/abook/${qrCode}/play-auth`;
+      const response = await axios.get(url, {
         params: { device_id: deviceId }
       });
       navigate(`/play/${qrCode}`, { state: { authData: response.data } });
@@ -26,62 +33,108 @@ const ScannerPage = () => {
       if (err.response) {
         setError(err.response.data.detail || t('error_auth_failed'));
       } else {
-        setError('An unexpected error occurred.');
+        setError(t('error_network'));
       }
     }
   }, [navigate, t]);
 
   useEffect(() => {
-    // This effect will run only once on component mount.
-    const html5QrCode = new Html5Qrcode(qrcodeRegionId);
-    let isScannerStopped = false;
+    const stopNative = () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach(track => track.stop());
+        streamRef.current = null;
+      }
+    };
 
-    const qrCodeSuccessCallback = (decodedText, decodedResult) => {
-        if (!isScannerStopped) {
-            isScannerStopped = true;
-            html5QrCode.stop().then(() => {
-                handleResult(decodedText);
-            }).catch((err) => {
-                console.error("Failed to stop scanner after success", err);
-                handleResult(decodedText); // Proceed even if stop fails
+    const startScanner = async () => {
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const videoDevices = devices.filter(d => d.kind === 'videoinput');
+        const deviceId = videoDevices[0]?.deviceId;
+
+        if ('BarcodeDetector' in window) {
+          const formats = await window.BarcodeDetector.getSupportedFormats();
+          if (formats.includes('qr_code')) {
+            useNativeRef.current = true;
+            setUseNative(true);
+            streamRef.current = await navigator.mediaDevices.getUserMedia({
+              video: deviceId ? { deviceId: { exact: deviceId } } : { facingMode: 'environment' }
             });
+            videoRef.current.srcObject = streamRef.current;
+            await videoRef.current.play();
+            const detector = new window.BarcodeDetector({ formats: ['qr_code'] });
+            const scan = async () => {
+              try {
+                const barcodes = await detector.detect(videoRef.current);
+                if (barcodes.length) {
+                  stopNative();
+                  handleResult(barcodes[0].rawValue);
+                  return;
+                }
+              } catch (e) {
+                // ignore detection errors
+              }
+              animationRef.current = requestAnimationFrame(scan);
+            };
+            animationRef.current = requestAnimationFrame(scan);
+            return;
+          }
         }
-    };
 
-    const qrCodeErrorCallback = (errorMessage) => {
-        // This callback is called frequently, so we don't set errors here
-        // to avoid spamming the user. It's useful for debugging.
-    };
-
-    const config = {
-        fps: 10,
-        qrbox: { width: 250, height: 250 },
-        rememberLastUsedCamera: true,
-    };
-
-    html5QrCode.start(
-        undefined, // Let the library select the camera
-        config,
-        qrCodeSuccessCallback,
-        qrCodeErrorCallback
-    ).catch((err) => {
+        html5QrCodeRef.current = new Html5Qrcode(qrcodeRegionId);
+        await html5QrCodeRef.current.start(
+          deviceId ? { deviceId: { exact: deviceId } } : { facingMode: 'environment' },
+          {
+            fps: 10,
+            qrbox: { width: 250, height: 250 },
+            rememberLastUsedCamera: true,
+            formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE]
+          },
+          (decodedText) => {
+            html5QrCodeRef.current
+              .stop()
+              .then(() => handleResult(decodedText))
+              .catch(err => {
+                console.error("Failed to stop scanner after success", err);
+                handleResult(decodedText);
+              });
+          },
+          () => {}
+        );
+      } catch (err) {
         setError(t('error_scanner'));
         console.error("Unable to start scanning.", err);
-    });
+      }
+    };
+
+    startScanner();
 
     return () => {
-        if (!isScannerStopped) {
-            html5QrCode.stop().catch(err => {
-                console.error("Failed to stop scanner on cleanup", err);
-            });
-        }
+      if (useNativeRef.current) {
+        stopNative();
+      } else if (html5QrCodeRef.current) {
+        html5QrCodeRef.current.stop().catch(err => {
+          console.error("Failed to stop scanner on cleanup", err);
+        });
+      }
     };
   }, [handleResult, t]);
 
   return (
     <div style={{ textAlign: 'center' }}>
       <h1>{t('scan_qr_title')}</h1>
-      <div id={qrcodeRegionId} style={{ width: '100%', maxWidth: '500px', margin: '0 auto' }} />
+      {useNative ? (
+        <video
+          ref={videoRef}
+          style={{ width: '100%', maxWidth: '500px', margin: '0 auto' }}
+        />
+      ) : (
+        <div
+          id={qrcodeRegionId}
+          style={{ width: '100%', maxWidth: '500px', margin: '0 auto' }}
+        />
+      )}
       <p>Point your camera at a QR code.</p>
       {error && <p style={{ color: 'red' }}>{error}</p>}
     </div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -45,5 +45,12 @@ export default defineConfig({
     watch: {
       usePolling: true,
     },
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- add native BarcodeDetector fallback for QR scanning
- retain Html5Qrcode as fallback for unsupported browsers
- build API URL relative to current origin to avoid CORS issues
- add localized network error messages
- proxy API requests through Vite dev server
- allow cross-origin requests in API via CORS middleware

## Testing
- `cd backend && pytest`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1b43b878c832e9befb380f32e12e5