### PR TITLE
fix: wait for minio before bucket setup

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -71,9 +71,11 @@ services:
       - MC_HOST_myminio=http://minioadmin:minioadmin@object-store:9000
     entrypoint: >
       /bin/sh -c "
+      until /usr/bin/mc ls myminio >/dev/null 2>&1; do sleep 1; done;
       /usr/bin/mc mb myminio/audiovook-test --ignore-existing;
-      /usr/bin/mc policy set download myminio/audiovook-test;
+      /usr/bin/mc anonymous set download myminio/audiovook-test;
       "
+    restart: on-failure
 
   proxy:
     image: nginx:latest


### PR DESCRIPTION
## Summary
- wait for MinIO to accept commands before creating bucket
- use `mc anonymous set download` and add restart policy to minio-setup

## Testing
- `python - <<'PY'
import yaml, sys
with open('infra/docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9b7b974c832eaff8cc895ac9c535