### PR TITLE
fix: wait for minio before bucket setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,7 @@
 AVOOK_SECRET=
 DB_URL=postgresql://user:password@db:5432/avook
 S3_ENDPOINT=http://object-store:9000
-S3_BUCKET=avook
+S3_BUCKET=audiovook-test
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 SIGNED_URL_TTL_MIN=15

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -69,11 +69,16 @@ services:
       - avook_net
     environment:
       - MC_HOST_myminio=http://minioadmin:minioadmin@object-store:9000
+    volumes:
+      - ./minio-cors.xml:/tmp/minio-cors.xml:ro
     entrypoint: >
       /bin/sh -c "
+      until /usr/bin/mc ls myminio >/dev/null 2>&1; do sleep 1; done;
       /usr/bin/mc mb myminio/audiovook-test --ignore-existing;
-      /usr/bin/mc policy set download myminio/audiovook-test;
+      /usr/bin/mc anonymous set download myminio/audiovook-test/*;
+      /usr/bin/mc cors set myminio/audiovook-test /tmp/minio-cors.xml;
       "
+    restart: on-failure
 
   proxy:
     image: nginx:latest

--- a/infra/minio-cors.xml
+++ b/infra/minio-cors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>*</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
+    <AllowedHeader>*</AllowedHeader>
+    <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+  </CORSRule>
+</CORSConfiguration>


### PR DESCRIPTION
## Summary
- wait for MinIO to accept commands before creating bucket
- set anonymous download policy for all objects and apply CORS via XML file

## Testing
- `python - <<'PY'
import yaml, sys
with open('infra/docker-compose.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('infra/minio-cors.xml')
print('XML OK')
PY`
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9b7b974c832eaff8cc895ac9c535