### PR TITLE
chore: replace minio with localstack

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,6 +1,6 @@
 # ✅ Roadmap Audiovook — Monorepo `avook-pwa` (Frontend + Backend + Infra)
 
-> **Objectiu:** PWA en React + API FastAPI + PostgreSQL + S3/MinIO, tot al mateix repositori i aixecat amb Docker Compose.
+> **Objectiu:** PWA en React + API FastAPI + PostgreSQL + S3 (LocalStack), tot al mateix repositori i aixecat amb Docker Compose.
 
 ## 📁 Estructura del repo
 - [x] `/frontend/` — PWA (React).
@@ -14,7 +14,7 @@
 - [x] **frontend** (5173) — parla amb `http://api:8000`.
 - [x] **api** (8000) — FastAPI.
 - [x] **db** (5432) — PostgreSQL (volum de dades).
-- [x] **object-store** (9000/9001) — MinIO S3.
+- [x] **object-store** (9000) — LocalStack S3.
 - [x] **proxy** (8080) — NGINX per HLS/CORS/Range.
 
 ## 🌱 Fase A — Bootstrap del monorepo
@@ -43,7 +43,7 @@
 - [x] Job **neteja** dispositius inactius (> X dies).
 **DoD:** proves amb curl/Postman; límit 2 dispositius; resume correcte.
 
-## ☁️ Fase D — S3/MinIO + Proxy (HLS)
+## ☁️ Fase D — S3 + Proxy (HLS)
 - [x] Bucket privat + policies; CORS habilitat.
 - [x] Estructura: `hls/{book_id}/...`, `covers/{book_id}.jpg`, `manifests/{book_id}.json`.
 - [x] Signatura d’URL per `master.m3u8` (TTL curt).

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This will start all the necessary services:
 - **PWA (Frontend):** http://localhost:5173
 - **API (Backend):** http://localhost:8000
 - **Stream Proxy (NGINX):** http://localhost:8080
-- **MinIO Console:** http://localhost:9001
+- **Local S3 (LocalStack):** http://localhost:9000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,9 +1,9 @@
 AVOOK_SECRET=
 DB_URL=postgresql://user:password@db:5432/avook
-S3_ENDPOINT=http://object-store:9000
-S3_BUCKET=avook
-S3_ACCESS_KEY=minioadmin
-S3_SECRET_KEY=minioadmin
+S3_ENDPOINT=http://object-store:4566
+S3_BUCKET=audiovook-test
+S3_ACCESS_KEY=test
+S3_SECRET_KEY=test
 SIGNED_URL_TTL_MIN=15
 S3_PUBLIC_ENDPOINT=http://localhost:8080
 INACTIVITY_DAYS=90

--- a/backend/s3_client.py
+++ b/backend/s3_client.py
@@ -49,7 +49,7 @@ def set_cors_policy():
         print(f"CORS policy set for bucket '{S3_BUCKET}'.")
     except ClientError as e:
         if e.response['Error']['Code'] == 'NotImplemented':
-            print(f"WARN: Could not set CORS policy on bucket '{S3_BUCKET}'. This might be a limitation of the local S3 server (MinIO). Continuing without setting CORS.")
+            print(f"WARN: Could not set CORS policy on bucket '{S3_BUCKET}'. This might be a limitation of the local S3 server (LocalStack). Continuing without setting CORS.")
         else:
             # For any other exception, re-raise it.
             print("Error setting CORS policy.")

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,9 +25,14 @@ services:
       - "8000:8000"
     env_file:
       - ../backend/.env
+    environment:
+      S3_ENDPOINT: http://object-store:4566
+      S3_BUCKET: audiovook-test
     depends_on:
-      - db
-      - object-store
+      db:
+        condition: service_healthy
+      s3-setup:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
@@ -44,36 +49,48 @@ services:
       - POSTGRES_DB=avook
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d avook"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
       - avook_net
 
   object-store:
-    image: minio/minio:latest
+    image: localstack/localstack:latest
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "9000:4566"
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
-    command: server /data --console-address ":9001"
+      - SERVICES=s3
+      - AWS_DEFAULT_REGION=us-east-1
     volumes:
-      - minio_data:/data
+      - localstack_data:/var/lib/localstack
     networks:
       - avook_net
 
-  minio-setup:
-    image: minio/mc
+  s3-setup:
+    image: amazon/aws-cli
     depends_on:
       - object-store
     networks:
       - avook_net
     environment:
-      - MC_HOST_myminio=http://minioadmin:minioadmin@object-store:9000
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      S3_BUCKET: audiovook-test
+    volumes:
+      - ./s3-cors.json:/tmp/s3-cors.json:ro
+      - ./s3-bucket-policy.json:/tmp/s3-bucket-policy.json:ro
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc mb myminio/audiovook-test --ignore-existing;
-      /usr/bin/mc policy set download myminio/audiovook-test;
+      until aws --endpoint-url http://object-store:4566 s3 ls >/dev/null 2>&1; do sleep 1; done;
+      aws --endpoint-url http://object-store:4566 s3 mb s3://$${S3_BUCKET} 2>/dev/null || true;
+      aws --endpoint-url http://object-store:4566 s3api put-bucket-policy --bucket $${S3_BUCKET} --policy file:///tmp/s3-bucket-policy.json;
+      aws --endpoint-url http://object-store:4566 s3api put-bucket-cors --bucket $${S3_BUCKET} --cors-configuration file:///tmp/s3-cors.json;
       "
+    restart: on-failure
 
   proxy:
     image: nginx:latest
@@ -94,4 +111,4 @@ networks:
 
 volumes:
   postgres_data:
-  minio_data:
+  localstack_data:

--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -6,9 +6,9 @@ server {
     access_log /dev/stdout;
     error_log /dev/stderr;
 
-    # This will proxy all requests to MinIO
+    # This will proxy all requests to the local S3 service
     location / {
-        proxy_pass http://object-store:9000;
+        proxy_pass http://object-store:4566;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/infra/s3-bucket-policy.json
+++ b/infra/s3-bucket-policy.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::audiovook-test/*"
+    }
+  ]
+}

--- a/infra/s3-cors.json
+++ b/infra/s3-cors.json
@@ -1,0 +1,10 @@
+{
+  "CORSRules": [
+    {
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET"],
+      "AllowedOrigins": ["*"],
+      "ExposeHeaders": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- switch object storage from MinIO to LocalStack S3 and automate bucket setup via AWS CLI
- update env examples and documentation to use LocalStack credentials and backup commands
- use LocalStack's internal port for inter-service requests and start API after S3 setup completes
- add default AWS credentials to the S3 setup helper to ensure bucket initialization
- add Postgres container healthcheck so services depending on the database can start reliably
- align S3 bucket configuration across API and setup containers to keep asset URLs consistent
- upload QR metadata JSON alongside images so pins can be retrieved in the admin UI
- surface QR pins and metadata links in the admin dashboard and streamline batch creation form

## Testing
- `python -m py_compile backend/api/v1/admin.py`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68be9b7b974c832eaff8cc895ac9c535