### PR TITLE
fix: ensure QR scanner works without explicit camera id

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,6 +1,6 @@
 # ✅ Roadmap Audiovook — Monorepo `avook-pwa` (Frontend + Backend + Infra)
 
-> **Objectiu:** PWA en React + API FastAPI + PostgreSQL + S3/MinIO, tot al mateix repositori i aixecat amb Docker Compose.
+> **Objectiu:** PWA en React + API FastAPI + PostgreSQL + S3 (LocalStack), tot al mateix repositori i aixecat amb Docker Compose.
 
 ## 📁 Estructura del repo
 - [x] `/frontend/` — PWA (React).
@@ -14,7 +14,7 @@
 - [x] **frontend** (5173) — parla amb `http://api:8000`.
 - [x] **api** (8000) — FastAPI.
 - [x] **db** (5432) — PostgreSQL (volum de dades).
-- [x] **object-store** (9000/9001) — MinIO S3.
+- [x] **object-store** (9000) — LocalStack S3.
 - [x] **proxy** (8080) — NGINX per HLS/CORS/Range.
 
 ## 🌱 Fase A — Bootstrap del monorepo
@@ -43,7 +43,7 @@
 - [x] Job **neteja** dispositius inactius (> X dies).
 **DoD:** proves amb curl/Postman; límit 2 dispositius; resume correcte.
 
-## ☁️ Fase D — S3/MinIO + Proxy (HLS)
+## ☁️ Fase D — S3 + Proxy (HLS)
 - [x] Bucket privat + policies; CORS habilitat.
 - [x] Estructura: `hls/{book_id}/...`, `covers/{book_id}.jpg`, `manifests/{book_id}.json`.
 - [x] Signatura d’URL per `master.m3u8` (TTL curt).

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This will start all the necessary services:
 - **PWA (Frontend):** http://localhost:5173
 - **API (Backend):** http://localhost:8000
 - **Stream Proxy (NGINX):** http://localhost:8080
-- **MinIO Console:** http://localhost:9001
+- **Local S3 (LocalStack):** http://localhost:9000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,9 +1,9 @@
 AVOOK_SECRET=
 DB_URL=postgresql://user:password@db:5432/avook
-S3_ENDPOINT=http://object-store:9000
-S3_BUCKET=avook
-S3_ACCESS_KEY=minioadmin
-S3_SECRET_KEY=minioadmin
+S3_ENDPOINT=http://object-store:4566
+S3_BUCKET=audiovook-test
+S3_ACCESS_KEY=test
+S3_SECRET_KEY=test
 SIGNED_URL_TTL_MIN=15
 S3_PUBLIC_ENDPOINT=http://localhost:8080
 INACTIVITY_DAYS=90

--- a/backend/api/v1/admin.py
+++ b/backend/api/v1/admin.py
@@ -309,9 +309,8 @@ async def upload_qrs_for_batch(
                     print(f"Skipping invalid JSON file {json_filename}: {e}")
                     continue
 
-            # Construct the expected PNG filename from metadata
-            date_str = metadata.date_generation.strftime('%Y-%m-%d')
-            expected_png_basename = f"{date_str}--{metadata.qr_code}.png"
+            # Use the provided image name to locate its PNG file
+            expected_png_basename = metadata.qr_image_name
 
             if expected_png_basename not in png_basenames:
                 print(f"No matching PNG found for {json_filename}. Expected: {expected_png_basename}")
@@ -329,6 +328,7 @@ async def upload_qrs_for_batch(
 
             pin_hash = auth.get_password_hash(str(metadata.pin))
             s3_key = f"qrcodes/{batch_id}/{metadata.qr_code}.png"
+            json_key = f"qrcodes/{batch_id}/{metadata.qr_code}.json"
 
             # Upload PNG to S3
             with zip_ref.open(png_filename) as png_file:
@@ -341,6 +341,18 @@ async def upload_qrs_for_batch(
                     )
                 except Exception as e:
                     raise HTTPException(status_code=500, detail=f"Failed to upload {png_filename} to S3: {str(e)}")
+            # Upload JSON metadata to S3
+            with zip_ref.open(json_filename) as metadata_file:
+                try:
+                    s3_client.s3_client.upload_fileobj(
+                        metadata_file,
+                        s3_client.S3_BUCKET,
+                        json_key,
+                        ExtraArgs={'ContentType': "application/json", 'ACL': "public-read"}
+                    )
+                except Exception as e:
+                    raise HTTPException(status_code=500, detail=f"Failed to upload {json_filename} to S3: {str(e)}")
+
 
             db_qr_code = models.QRCode(
                 product_id=db_batch.product_id,
@@ -353,7 +365,10 @@ async def upload_qrs_for_batch(
             qr_codes_to_create.append(db_qr_code)
 
     if valid_pairs_found == 0:
-        raise HTTPException(status_code=400, detail="No valid QR code files found in the zip archive.")
+        raise HTTPException(
+            status_code=400,
+            detail="No valid QR code files found in the zip archive.",
+        )
 
     if qr_codes_to_create:
         db.bulk_save_objects(qr_codes_to_create)

--- a/backend/run.py
+++ b/backend/run.py
@@ -3,4 +3,4 @@ from main import app
 
 if __name__ == "__main__":
     print("--- Starting Uvicorn server from run.py ---")
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=False)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=False, access_log=False)

--- a/backend/s3_client.py
+++ b/backend/s3_client.py
@@ -1,4 +1,5 @@
 import os
+import json
 import boto3
 from botocore.client import Config
 from botocore.exceptions import ClientError
@@ -6,7 +7,7 @@ from botocore.exceptions import ClientError
 S3_ENDPOINT = os.getenv("S3_ENDPOINT")
 S3_ACCESS_KEY = os.getenv("S3_ACCESS_KEY")
 S3_SECRET_KEY = os.getenv("S3_SECRET_KEY")
-S3_BUCKET = os.getenv("S3_BUCKET")
+S3_BUCKET = os.getenv("S3_BUCKET", "audiovook-test")
 S3_PUBLIC_ENDPOINT = os.getenv("S3_PUBLIC_ENDPOINT")
 
 s3_client = boto3.client(
@@ -27,6 +28,7 @@ def create_bucket_if_not_exists():
             print(f"Bucket '{S3_BUCKET}' not found. Creating it.")
             s3_client.create_bucket(Bucket=S3_BUCKET)
             set_cors_policy()
+            set_public_read_policy()
         else:
             # For any other exception, re-raise it.
             print("Error checking bucket existence.")
@@ -49,8 +51,27 @@ def set_cors_policy():
         print(f"CORS policy set for bucket '{S3_BUCKET}'.")
     except ClientError as e:
         if e.response['Error']['Code'] == 'NotImplemented':
-            print(f"WARN: Could not set CORS policy on bucket '{S3_BUCKET}'. This might be a limitation of the local S3 server (MinIO). Continuing without setting CORS.")
+            print(f"WARN: Could not set CORS policy on bucket '{S3_BUCKET}'. This might be a limitation of the local S3 server (LocalStack). Continuing without setting CORS.")
         else:
             # For any other exception, re-raise it.
             print("Error setting CORS policy.")
             raise
+
+def set_public_read_policy():
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": f"arn:aws:s3:::{S3_BUCKET}/*",
+            }
+        ],
+    }
+    try:
+        s3_client.put_bucket_policy(Bucket=S3_BUCKET, Policy=json.dumps(policy))
+        print(f"Public read policy set for bucket '{S3_BUCKET}'.")
+    except ClientError:
+        print(f"Error setting public policy for bucket '{S3_BUCKET}'.")
+        raise

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -123,6 +123,16 @@ class QRCodeDetails(QRCode):
 
 
 class QRCodeMetadata(BaseModel):
-    qr_code: str
-    date_generation: datetime
+    qr_image_name: str
+    product_id: Optional[str] = None
+    date_generation: Optional[datetime] = None
+    pvp: Optional[int] = None
+    pvp_currentcy: Optional[str] = None
+    status: Optional[str] = None
+    shop_id: Optional[str] = None
     pin: str
+    qr_code: str
+    avook_url: Optional[str] = None
+
+    class Config:
+        extra = "allow"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,5 +22,5 @@ COPY --from=build /app/package.json .
 # Make port 5173 available
 EXPOSE 5173
 
-# Serve the production build, correctly handling SPA routing
-CMD ["./node_modules/.bin/serve", "-s", "dist", "-l", "5173"]
+# Serve the production build without noisy request logs
+CMD ["./node_modules/.bin/serve", "-s", "dist", "-l", "5173", "--no-request-logging"]

--- a/frontend/src/pages/ScannerPage.jsx
+++ b/frontend/src/pages/ScannerPage.jsx
@@ -1,58 +1,25 @@
+
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
 import { useTranslation } from 'react-i18next';
-import { getDeviceId } from '../services/device';
 import { Html5Qrcode } from 'html5-qrcode';
 
 const ScannerPage = () => {
   const { t } = useTranslation();
   const [error, setError] = useState('');
-  const [useNative, setUseNative] = useState(false);
-  const navigate = useNavigate();
   const videoRef = useRef(null);
   const streamRef = useRef(null);
   const animationRef = useRef(null);
   const html5QrRef = useRef(null);
-  const handleResult = useCallback(async (qrCode) => {
+  const handleResult = useCallback((qrCode) => {
     setError('');
+    console.log('QR detected:', qrCode);
     try {
-      let extractedCode = null;
-      try {
-        const url = new URL(qrCodeUrl);
-        const match = url.pathname.match(/\/code\/([^\/]+)/) || url.pathname.match(/\/share\/([^\/]+)/);
-        if (match && match[1]) {
-          extractedCode = match[1];
-        }
-      } catch (e) {
-        // Not a valid URL, maybe the QR code is the code itself
-        extractedCode = qrCodeUrl;
-      }
-
-      if (!extractedCode) {
-        setError(t('error_invalid_qr'));
-        return;
-      }
-
-      const deviceId = await getDeviceId();
-      const baseFromEnv = import.meta.env.VITE_API_BASE;
-      const fallbackBase = window.location.port === '5173' ? 'http://localhost:8000' : '';
-      const apiBase = (baseFromEnv || fallbackBase).replace(/\/$/, '');
-      const slug = qrCode.trim().split('/').pop();
-      const url = `${apiBase}/api/v1/abook/${slug}/play-auth`;
-      const response = await axios.get(url, {
-        params: { device_id: deviceId }
-      });
-      navigate(`/play/${slug}`, { state: { authData: response.data } });
+      const url = new URL(qrCode);
+      window.location.href = url.toString();
     } catch (err) {
-      console.error('API Error:', err);
-      if (err.response) {
-        setError(err.response.data.detail || t('error_auth_failed'));
-      } else {
-        setError(t('error_network'));
-      }
+      setError(t('error_invalid_qr'));
     }
-  }, [navigate, t]);
+  }, [t]);
 
   useEffect(() => {
     const stop = () => {
@@ -73,7 +40,9 @@ const ScannerPage = () => {
     const startScanner = async () => {
       try {
         const cameras = await Html5Qrcode.getCameras();
-        const deviceId = cameras[0]?.id;
+        const deviceId = cameras.find(c =>
+          /back|rear|environment/i.test(c.label)
+        )?.id || cameras[0]?.id;
 
         const qrRegion = document.getElementById('qr-reader');
 
@@ -113,8 +82,9 @@ const ScannerPage = () => {
         if (qrRegion) qrRegion.style.display = 'block';
         videoRef.current.style.display = 'none';
         html5QrRef.current = new Html5Qrcode('qr-reader');
+        const cameraConfig = deviceId || { facingMode: 'environment' };
         await html5QrRef.current.start(
-          { deviceId: { exact: deviceId } },
+          cameraConfig,
           { fps: 10, qrbox: 250 },
           (decodedText) => {
             stop();

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,9 +25,14 @@ services:
       - "8000:8000"
     env_file:
       - ../backend/.env
+    environment:
+      S3_ENDPOINT: http://object-store:4566
+      S3_BUCKET: audiovook-test
     depends_on:
-      - db
-      - object-store
+      db:
+        condition: service_healthy
+      s3-setup:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 10s
@@ -38,42 +43,55 @@ services:
 
   db:
     image: postgres:15
+    command: ["postgres", "-c", "log_checkpoints=off", "-c", "log_min_messages=warning"]
     environment:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=avook
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d avook"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
       - avook_net
 
   object-store:
-    image: minio/minio:latest
+    image: localstack/localstack:latest
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "9000:4566"
     environment:
-      - MINIO_ROOT_USER=minioadmin
-      - MINIO_ROOT_PASSWORD=minioadmin
-    command: server /data --console-address ":9001"
+      - SERVICES=s3
+      - AWS_DEFAULT_REGION=us-east-1
     volumes:
-      - minio_data:/data
+      - localstack_data:/var/lib/localstack
     networks:
       - avook_net
 
-  minio-setup:
-    image: minio/mc
+  s3-setup:
+    image: amazon/aws-cli
     depends_on:
       - object-store
     networks:
       - avook_net
     environment:
-      - MC_HOST_myminio=http://minioadmin:minioadmin@object-store:9000
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_DEFAULT_REGION: us-east-1
+      S3_BUCKET: audiovook-test
+    volumes:
+      - ./s3-cors.json:/tmp/s3-cors.json:ro
+      - ./s3-bucket-policy.json:/tmp/s3-bucket-policy.json:ro
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc mb myminio/audiovook-test --ignore-existing;
-      /usr/bin/mc policy set download myminio/audiovook-test;
+      until aws --endpoint-url http://object-store:4566 s3 ls >/dev/null 2>&1; do sleep 1; done;
+      aws --endpoint-url http://object-store:4566 s3 mb s3://$${S3_BUCKET} 2>/dev/null || true;
+      aws --endpoint-url http://object-store:4566 s3api put-bucket-policy --bucket $${S3_BUCKET} --policy file:///tmp/s3-bucket-policy.json;
+      aws --endpoint-url http://object-store:4566 s3api put-bucket-cors --bucket $${S3_BUCKET} --cors-configuration file:///tmp/s3-cors.json;
       "
+    restart: on-failure
 
   proxy:
     image: nginx:latest
@@ -94,4 +112,4 @@ networks:
 
 volumes:
   postgres_data:
-  minio_data:
+  localstack_data:

--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -6,9 +6,9 @@ server {
     access_log /dev/stdout;
     error_log /dev/stderr;
 
-    # This will proxy all requests to MinIO
+    # This will proxy all requests to the local S3 service
     location / {
-        proxy_pass http://object-store:9000;
+        proxy_pass http://object-store:4566;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/infra/s3-bucket-policy.json
+++ b/infra/s3-bucket-policy.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::audiovook-test/*"
+    }
+  ]
+}

--- a/infra/s3-cors.json
+++ b/infra/s3-cors.json
@@ -1,0 +1,10 @@
+{
+  "CORSRules": [
+    {
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET"],
+      "AllowedOrigins": ["*"],
+      "ExposeHeaders": []
+    }
+  ]
+}

--- a/test_qrs/qr1.json
+++ b/test_qrs/qr1.json
@@ -1,1 +1,12 @@
-{"qr": "qr-test-1", "pin": "1111"}
+{
+  "qr_image_name": "2025-01-01--qr-test-1.png",
+  "product_id": "1",
+  "date_generation": "2025-01-01T00:00:00+00:00",
+  "pvp": 10,
+  "pvp_currentcy": "euro",
+  "status": "ready",
+  "shop_id": null,
+  "pin": "1111",
+  "qr_code": "qr-test-1",
+  "avook_url": "https://audiovook.com/qr/code/qr-test-1"
+}

--- a/test_qrs/qr2.json
+++ b/test_qrs/qr2.json
@@ -1,1 +1,12 @@
-{"qr": "qr-test-2", "pin": "2222"}
+{
+  "qr_image_name": "2025-01-01--qr-test-2.png",
+  "product_id": "1",
+  "date_generation": "2025-01-01T00:00:00+00:00",
+  "pvp": 10,
+  "pvp_currentcy": "euro",
+  "status": "ready",
+  "shop_id": null,
+  "pin": "2222",
+  "qr_code": "qr-test-2",
+  "avook_url": "https://audiovook.com/qr/code/qr-test-2"
+}


### PR DESCRIPTION
## Summary
- use direct device id or environment camera fallback when starting Html5Qrcode
- prioritize rear camera if multiple cameras are available
- silence health check access logs and log detected QR codes
- suppress noisy container logs by disabling frontend request logging and Postgres checkpoint messages

## Testing
- `python -m py_compile backend/run.py backend/api/v1/admin.py backend/schemas.py backend/s3_client.py`
- `npm --prefix frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be9b7b974c832eaff8cc895ac9c535