### PR TITLE
Use shared API helper for access validation

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,13 +1,20 @@
 const API_BASE = import.meta.env.VITE_API_BASE ?? '/api';
 
-export async function apiFetch<T>(endpoint: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE}${endpoint}`, {
+export async function apiFetch<T>(
+  endpoint: string,
+  init: RequestInit = {},
+  fetcher: typeof fetch = fetch
+): Promise<T> {
+  const response = await fetcher(`${API_BASE}${endpoint}`, {
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init.headers ?? {})
-    },
-    ...init
+    ...init,
+    headers:
+      init.headers instanceof Headers || Array.isArray(init.headers)
+        ? init.headers
+        : {
+            'Content-Type': 'application/json',
+            ...(init.headers ?? {})
+          }
   });
 
   if (!response.ok) {

--- a/apps/web/src/routes/access/+page.ts
+++ b/apps/web/src/routes/access/+page.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from '$lib/api';
 import type { PageLoad } from './$types';
 
 const DEMO_TOKENS = ['DEMO-ALPHA', 'DEMO-BETA', 'DEMO-GAMMA'] as const;
@@ -35,20 +36,17 @@ export const load: PageLoad = async ({ url, fetch }) => {
   }
 
   try {
-    const response = await fetch('/api/access/validate', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
+    const payload = await apiFetch<AccessValidation>(
+      '/access/validate',
+      {
+        method: 'POST',
+        body: JSON.stringify({ token })
       },
-      body: JSON.stringify({ token })
-    });
+      fetch
+    );
 
-    const payload = (await response.json()) as AccessValidation;
-
-    if (!response.ok || !payload?.status) {
-      const errorMessage = !response.ok
-        ? `HTTP ${response.status}`
-        : 'Unknown validation response';
+    if (!payload?.status) {
+      const errorMessage = 'Unknown validation response';
 
       return {
         token,


### PR DESCRIPTION
## Summary
- update the access page load function to retrieve validation data via the shared apiFetch helper so SSR requests target the correct API host
- enhance apiFetch to accept a custom fetch implementation while preserving default headers for JSON requests

## Testing
- npm run check *(fails: existing +page.svelte template is missing a closing </script> tag)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6135c104832eab5e1442938eb399