### PR TITLE
Implement access registration and rate limiting

### DIFF
--- a/apps/api/app/api/access.py
+++ b/apps/api/app/api/access.py
@@ -2,18 +2,79 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
+import logging
 import uuid
-from datetime import datetime
-from typing import Literal, Optional
+from datetime import datetime, timedelta
+from typing import Any, Literal, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
+from sqlalchemy import func
 from sqlmodel import Session, select
 
 from app.core.database import get_session
-from app.models import QrCode, QrStatus
+from app.core.rate_limit import DEFAULT_ACCESS_RULE, RateLimitExceeded, RateLimiter
+from app.models import Device, QrBinding, QrCode, QrStatus
 
-router = APIRouter(prefix="/access")
+logger = logging.getLogger("app.access")
+
+rate_limiter = RateLimiter()
+
+
+def _hash_identifier(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _log_event(
+    request: Request,
+    event_type: str,
+    token: str,
+    device_id: Optional[uuid.UUID],
+    **extra: Any,
+) -> None:
+    client_host = request.client.host if request.client else ""
+    request_id = request.headers.get("X-Request-ID")
+    user_agent = request.headers.get("User-Agent", "unknown")
+
+    payload: dict[str, Any] = {
+        "event_type": event_type,
+        "token_hash": _hash_identifier(token),
+        "device_id": str(device_id) if device_id else None,
+        "ip_hash": _hash_identifier(client_host) if client_host else None,
+        "request_id": request_id,
+        "user_agent_hash": _hash_identifier(user_agent),
+    }
+    if extra:
+        payload.update(extra)
+
+    logger.info(json.dumps(payload))
+
+
+def enforce_access_rate_limit(request: Request) -> None:
+    client_host = request.client.host if request.client else "anonymous"
+    key = f"access:{client_host}"
+
+    try:
+        rate_limiter.check(key, DEFAULT_ACCESS_RULE)
+    except RateLimitExceeded as exc:  # pragma: no cover - handled via HTTPException
+        retry_after = RateLimiter.format_retry_after(exc.retry_after)
+        _log_event(
+            request,
+            "access.rate_limited",
+            token="",
+            device_id=None,
+            retry_after=retry_after,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many requests",
+            headers={"Retry-After": retry_after},
+        ) from exc
+
+
+router = APIRouter(prefix="/access", dependencies=[Depends(enforce_access_rate_limit)])
 
 
 class AccessValidateRequest(BaseModel):
@@ -49,6 +110,29 @@ def _build_product_payload(qr: QrCode) -> Optional[ProductInfo]:
     return ProductInfo(id=qr.product_id, title=title)
 
 
+def _build_validation_payload(qr_code: QrCode) -> AccessValidateResponse:
+    if qr_code.status is QrStatus.BLOCKED:
+        status: Literal["new", "registered", "invalid", "blocked"] = "blocked"
+    elif qr_code.status is QrStatus.NEW:
+        status = "new"
+    else:
+        status = "registered"
+
+    cooldown_active = (
+        qr_code.cooldown_until is not None
+        and qr_code.cooldown_until > datetime.utcnow()
+    )
+
+    return AccessValidateResponse(
+        status=status,
+        can_reregister=status in {"new", "registered"} and not cooldown_active,
+        preview_available=status != "blocked",
+        cooldown_until=qr_code.cooldown_until,
+        product=_build_product_payload(qr_code),
+        token=qr_code.token,
+    )
+
+
 @router.post("/validate", response_model=AccessValidateResponse)
 def validate_access(
     payload: AccessValidateRequest,
@@ -80,21 +164,267 @@ def validate_access(
             token=token,
         )
 
-    if qr_code.status is QrStatus.BLOCKED:
-        status: Literal["new", "registered", "invalid", "blocked"] = "blocked"
-    elif qr_code.status is QrStatus.NEW:
-        status = "new"
-    else:
-        status = "registered"
+    return _build_validation_payload(qr_code)
 
-    return AccessValidateResponse(
-        status=status,
-        can_reregister=status in {"new", "registered"},
-        preview_available=status != "blocked",
-        cooldown_until=qr_code.cooldown_until,
-        product=_build_product_payload(qr_code),
-        token=qr_code.token,
+
+class AccessRegisterRequest(BaseModel):
+    """Payload for the initial device registration flow."""
+
+    token: str = Field(..., min_length=1)
+    device_id: uuid.UUID
+    account_id: Optional[uuid.UUID] = None
+
+
+class AccessReregisterRequest(BaseModel):
+    """Payload for moving an existing binding to a new device."""
+
+    token: str = Field(..., min_length=1)
+    new_device_id: uuid.UUID
+    account_id: Optional[uuid.UUID] = None
+
+
+def _get_active_binding(session: Session, qr_id: uuid.UUID) -> Optional[QrBinding]:
+    binding_query = (
+        select(QrBinding)
+        .where(QrBinding.qr_id == qr_id)
+        .where(QrBinding.active.is_(True))
     )
+    return session.exec(binding_query).first()
+
+
+def _ensure_device(
+    session: Session,
+    device_id: uuid.UUID,
+    ua_hash: str,
+    account_id: Optional[uuid.UUID],
+) -> Device:
+    device = session.get(Device, device_id)
+    if device is None:
+        device = Device(id=device_id, ua_hash=ua_hash, account_id=account_id)
+        session.add(device)
+    elif account_id is not None and device.account_id != account_id:
+        device.account_id = account_id
+    return device
+
+
+def _check_cooldown(
+    qr_code: QrCode,
+    request: Request,
+    token: str,
+    device_id: uuid.UUID,
+    action: str,
+) -> None:
+    if (
+        qr_code.cooldown_until is not None
+        and qr_code.cooldown_until > datetime.utcnow()
+    ):
+        _log_event(
+            request,
+            f"access.{action}.cooldown",
+            token,
+            device_id,
+            cooldown_until=qr_code.cooldown_until.isoformat(),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token is temporarily on cooldown",
+        )
+
+
+@router.post("/register", response_model=AccessValidateResponse)
+def register_access(
+    payload: AccessRegisterRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> AccessValidateResponse:
+    """Create the initial binding between a QR token and a device."""
+
+    token = payload.token.strip()
+    if not token:
+        _log_event(request, "access.register.invalid", payload.token, payload.device_id)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Token is required")
+
+    qr_code = session.exec(select(QrCode).where(QrCode.token == token)).first()
+    if qr_code is None:
+        _log_event(request, "access.register.not_found", token, payload.device_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
+
+    if qr_code.status is QrStatus.BLOCKED:
+        _log_event(request, "access.register.blocked", token, payload.device_id)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is blocked")
+
+    _check_cooldown(qr_code, request, token, payload.device_id, "register")
+
+    active_binding = _get_active_binding(session, qr_code.id)
+    if active_binding is not None:
+        if active_binding.device_id == payload.device_id:
+            if (
+                payload.account_id is not None
+                and active_binding.account_id != payload.account_id
+            ):
+                active_binding.account_id = payload.account_id
+                session.add(active_binding)
+                session.commit()
+                session.refresh(qr_code)
+            _log_event(request, "access.register.idempotent", token, payload.device_id)
+            return _build_validation_payload(qr_code)
+
+        _log_event(
+            request,
+            "access.register.conflict",
+            token,
+            payload.device_id,
+            conflict_device=str(active_binding.device_id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Token already bound to a different device",
+        )
+
+    ua_hash = _hash_identifier(request.headers.get("User-Agent", "unknown"))
+    _ensure_device(session, payload.device_id, ua_hash, payload.account_id)
+
+    binding = QrBinding(
+        qr_id=qr_code.id,
+        device_id=payload.device_id,
+        account_id=payload.account_id,
+        active=True,
+    )
+    session.add(binding)
+
+    qr_code.status = QrStatus.ACTIVE
+    qr_code.registered_at = datetime.utcnow()
+    session.add(qr_code)
+
+    session.commit()
+    session.refresh(qr_code)
+
+    _log_event(
+        request,
+        "access.register.success",
+        token,
+        payload.device_id,
+        account_id=str(payload.account_id) if payload.account_id else None,
+    )
+
+    return _build_validation_payload(qr_code)
+
+
+def _count_total_bindings(session: Session, qr_id: uuid.UUID) -> int:
+    return session.exec(
+        select(func.count())
+        .select_from(QrBinding)
+        .where(QrBinding.qr_id == qr_id)
+    ).one()
+
+
+def _count_recent_reactivations(session: Session, qr_id: uuid.UUID, now: datetime) -> int:
+    cutoff = now - timedelta(hours=24)
+    return session.exec(
+        select(func.count())
+        .select_from(QrBinding)
+        .where(QrBinding.qr_id == qr_id)
+        .where(QrBinding.revoked_at.is_not(None))
+        .where(QrBinding.revoked_at >= cutoff)
+    ).one()
+
+
+@router.post("/reregister", response_model=AccessValidateResponse)
+def reregister_access(
+    payload: AccessReregisterRequest,
+    request: Request,
+    session: Session = Depends(get_session),
+) -> AccessValidateResponse:
+    """Move an existing registration to a new device."""
+
+    token = payload.token.strip()
+    if not token:
+        _log_event(request, "access.reregister.invalid", payload.token, payload.new_device_id)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Token is required")
+
+    qr_code = session.exec(select(QrCode).where(QrCode.token == token)).first()
+    if qr_code is None:
+        _log_event(request, "access.reregister.not_found", token, payload.new_device_id)
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Token not found")
+
+    if qr_code.status is QrStatus.BLOCKED:
+        _log_event(request, "access.reregister.blocked", token, payload.new_device_id)
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Token is blocked")
+
+    _check_cooldown(qr_code, request, token, payload.new_device_id, "reregister")
+
+    active_binding = _get_active_binding(session, qr_code.id)
+    if active_binding is None:
+        _log_event(request, "access.reregister.missing_binding", token, payload.new_device_id)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="No active registration to move",
+        )
+
+    if active_binding.device_id == payload.new_device_id:
+        if (
+            payload.account_id is not None
+            and active_binding.account_id != payload.account_id
+        ):
+            active_binding.account_id = payload.account_id
+            session.add(active_binding)
+            session.commit()
+            session.refresh(qr_code)
+        _log_event(request, "access.reregister.idempotent", token, payload.new_device_id)
+        return _build_validation_payload(qr_code)
+
+    total_bindings = _count_total_bindings(session, qr_code.id)
+    if total_bindings - 1 >= qr_code.max_reactivations:
+        _log_event(
+            request,
+            "access.reregister.max_reached",
+            token,
+            payload.new_device_id,
+            total_bindings=total_bindings,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Maximum number of re-registrations reached",
+        )
+
+    now = datetime.utcnow()
+
+    active_binding.active = False
+    active_binding.revoked_at = now
+    session.add(active_binding)
+
+    ua_hash = _hash_identifier(request.headers.get("User-Agent", "unknown"))
+    _ensure_device(session, payload.new_device_id, ua_hash, payload.account_id)
+
+    new_binding = QrBinding(
+        qr_id=qr_code.id,
+        device_id=payload.new_device_id,
+        account_id=payload.account_id,
+        active=True,
+    )
+    session.add(new_binding)
+
+    qr_code.status = QrStatus.ACTIVE
+    qr_code.registered_at = now
+
+    recent_reactivations = _count_recent_reactivations(session, qr_code.id, now)
+    if recent_reactivations > 3:
+        qr_code.cooldown_until = now + timedelta(hours=48)
+
+    session.add(qr_code)
+    session.commit()
+    session.refresh(qr_code)
+
+    _log_event(
+        request,
+        "access.reregister.success",
+        token,
+        payload.new_device_id,
+        account_id=str(payload.account_id) if payload.account_id else None,
+        recent_reactivations=recent_reactivations,
+    )
+
+    return _build_validation_payload(qr_code)
 
 
 __all__ = ["router"]

--- a/apps/api/app/core/rate_limit.py
+++ b/apps/api/app/core/rate_limit.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import math
+import threading
+import time
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import timedelta
+from typing import Deque, DefaultDict
 
 
 @dataclass(slots=True)
@@ -14,5 +19,60 @@ class RateLimitRule:
     period: timedelta
 
 
+class RateLimitExceeded(Exception):
+    """Raised when a rate limit has been exceeded."""
+
+    def __init__(self, retry_after: float) -> None:
+        self.retry_after = max(0.0, retry_after)
+        super().__init__(f"Rate limit exceeded. Retry after {self.retry_after:.2f}s")
+
+
+class RateLimiter:
+    """Simple in-memory rate limiter suitable for unit tests."""
+
+    def __init__(self) -> None:
+        self._buckets: DefaultDict[str, Deque[float]] = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def check(self, key: str, rule: RateLimitRule) -> None:
+        """Register a request and raise if the limit would be exceeded."""
+
+        now = time.monotonic()
+        window_start = now - rule.period.total_seconds()
+
+        with self._lock:
+            bucket = self._buckets[key]
+
+            while bucket and bucket[0] < window_start:
+                bucket.popleft()
+
+            if len(bucket) >= rule.requests:
+                retry_after = bucket[0] + rule.period.total_seconds() - now
+                raise RateLimitExceeded(retry_after)
+
+            bucket.append(now)
+
+    def reset(self) -> None:
+        """Clear all tracking state (primarily for tests)."""
+
+        with self._lock:
+            self._buckets.clear()
+
+    @staticmethod
+    def format_retry_after(seconds: float) -> str:
+        """Return a header-friendly retry-after value."""
+
+        return str(max(1, math.ceil(seconds)))
+
+
 DEFAULT_ACCESS_RULE = RateLimitRule(requests=30, period=timedelta(minutes=1))
 DEFAULT_PREVIEW_RULE = RateLimitRule(requests=10, period=timedelta(minutes=1))
+
+
+__all__ = [
+    "DEFAULT_ACCESS_RULE",
+    "DEFAULT_PREVIEW_RULE",
+    "RateLimitExceeded",
+    "RateLimitRule",
+    "RateLimiter",
+]

--- a/apps/api/tests/api/test_access_register.py
+++ b/apps/api/tests/api/test_access_register.py
@@ -1,0 +1,199 @@
+"""Tests for the access registration and re-registration flows."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.core.database import get_engine
+from app.models import QrBinding, QrCode, QrStatus
+
+
+def _get_session() -> Session:
+    return Session(get_engine())
+
+
+def _post_json(client: TestClient, path: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
+    response = client.post(path, json=payload)
+    data = response.json() if response.content else {}
+    return response.status_code, data
+
+
+def test_register_creates_binding_and_updates_qr(client: TestClient) -> None:
+    token = "DEMO-NEW"
+    device_id = uuid.uuid4()
+
+    status_code, payload = _post_json(
+        client,
+        "/api/access/register",
+        {"token": token, "device_id": str(device_id)},
+    )
+
+    assert status_code == 200
+    assert payload["status"] == "registered"
+
+    with _get_session() as session:
+        qr_code = session.exec(select(QrCode).where(QrCode.token == token)).one()
+        assert qr_code.status is QrStatus.ACTIVE
+        assert qr_code.registered_at is not None
+
+        binding = session.exec(
+            select(QrBinding).where(QrBinding.qr_id == qr_code.id)
+        ).one()
+        assert binding.active is True
+        assert binding.device_id == device_id
+
+
+def test_register_conflict_when_already_bound(client: TestClient) -> None:
+    token = "DEMO-NEW"
+    original_device = uuid.uuid4()
+    _post_json(client, "/api/access/register", {"token": token, "device_id": str(original_device)})
+
+    new_device = uuid.uuid4()
+    status_code, payload = _post_json(
+        client,
+        "/api/access/register",
+        {"token": token, "device_id": str(new_device)},
+    )
+
+    assert status_code == 409
+    assert payload["detail"] == "Token already bound to a different device"
+
+
+def test_register_is_idempotent_and_updates_account(client: TestClient) -> None:
+    token = "DEMO-NEW"
+    device_id = uuid.uuid4()
+    account_id = uuid.uuid4()
+
+    _post_json(client, "/api/access/register", {"token": token, "device_id": str(device_id)})
+
+    status_code, _ = _post_json(
+        client,
+        "/api/access/register",
+        {"token": token, "device_id": str(device_id), "account_id": str(account_id)},
+    )
+
+    assert status_code == 200
+
+    with _get_session() as session:
+        qr_code = session.exec(select(QrCode).where(QrCode.token == token)).one()
+        binding = session.exec(
+            select(QrBinding).where(QrBinding.qr_id == qr_code.id)
+        ).one()
+        assert binding.account_id == account_id
+
+
+def test_reregister_moves_binding_to_new_device(client: TestClient) -> None:
+    token = "DEMO-NEW"
+    device_a = uuid.uuid4()
+    device_b = uuid.uuid4()
+
+    _post_json(client, "/api/access/register", {"token": token, "device_id": str(device_a)})
+
+    status_code, payload = _post_json(
+        client,
+        "/api/access/reregister",
+        {"token": token, "new_device_id": str(device_b)},
+    )
+
+    assert status_code == 200
+    assert payload["status"] == "registered"
+
+    with _get_session() as session:
+        qr_code = session.exec(select(QrCode).where(QrCode.token == token)).one()
+        bindings = session.exec(
+            select(QrBinding).where(QrBinding.qr_id == qr_code.id)
+        ).all()
+        assert len(bindings) == 2
+
+        active_binding = next(binding for binding in bindings if binding.active)
+        inactive_binding = next(binding for binding in bindings if not binding.active)
+
+        assert active_binding.device_id == device_b
+        assert inactive_binding.device_id == device_a
+        assert inactive_binding.revoked_at is not None
+
+
+def test_reregister_respects_max_reactivations(client: TestClient) -> None:
+    token = "LIMITED-TOKEN"
+    device_a = uuid.uuid4()
+    device_b = uuid.uuid4()
+
+    with _get_session() as session:
+        qr_code = QrCode(token=token, status=QrStatus.NEW, max_reactivations=0)
+        session.add(qr_code)
+        session.commit()
+
+    _post_json(client, "/api/access/register", {"token": token, "device_id": str(device_a)})
+
+    status_code, payload = _post_json(
+        client,
+        "/api/access/reregister",
+        {"token": token, "new_device_id": str(device_b)},
+    )
+
+    assert status_code == 403
+    assert payload["detail"] == "Maximum number of re-registrations reached"
+
+
+def test_reregister_triggers_cooldown_after_multiple_events(client: TestClient) -> None:
+    token = "DEMO-NEW"
+    devices = [uuid.uuid4() for _ in range(6)]
+
+    _post_json(client, "/api/access/register", {"token": token, "device_id": str(devices[0])})
+
+    for index in range(1, 5):
+        status_code, _ = _post_json(
+            client,
+            "/api/access/reregister",
+            {"token": token, "new_device_id": str(devices[index])},
+        )
+        assert status_code == 200
+
+    with _get_session() as session:
+        qr_code = session.exec(select(QrCode).where(QrCode.token == token)).one()
+        assert qr_code.cooldown_until is not None
+        assert qr_code.cooldown_until > datetime.utcnow()
+
+    status_code, payload = _post_json(
+        client,
+        "/api/access/validate",
+        {"token": token},
+    )
+
+    assert status_code == 200
+    assert payload["can_reregister"] is False
+
+
+def test_rate_limit_blocks_after_threshold(client: TestClient) -> None:
+    for _ in range(30):
+        status_code, _ = _post_json(client, "/api/access/validate", {"token": "DEMO-NEW"})
+        assert status_code == 200
+
+    response = client.post("/api/access/validate", json={"token": "DEMO-NEW"})
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+
+
+def test_register_logs_hashed_token(client: TestClient, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="app.access")
+    token = "DEMO-NEW"
+    device_id = uuid.uuid4()
+
+    expected_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    status_code, _ = _post_json(
+        client,
+        "/api/access/register",
+        {"token": token, "device_id": str(device_id)},
+    )
+
+    assert status_code == 200
+    assert expected_hash in caplog.text
+    assert token not in caplog.text

--- a/apps/api/tests/api/test_access_validate.py
+++ b/apps/api/tests/api/test_access_validate.py
@@ -2,35 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, create_engine
-from sqlalchemy.pool import StaticPool
-
-from app import create_app
-from app.core.database import configure_engine
-from app.models import QrCode, QrStatus, metadata
-
-
-@pytest.fixture()
-def client() -> TestClient:
-    """Provide a FastAPI test client backed by an in-memory database."""
-
-    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
-    metadata.create_all(engine)
-    configure_engine(engine)
-
-    with Session(engine) as session:
-        session.add(QrCode(token="DEMO-NEW", status=QrStatus.NEW, product_id=1))
-        session.add(QrCode(token="DEMO-ACTIVE", status=QrStatus.ACTIVE, product_id=2))
-        session.add(QrCode(token="DEMO-BLOCKED", status=QrStatus.BLOCKED, product_id=3))
-        session.commit()
-
-    app = create_app()
-    with TestClient(app) as test_client:
-        yield test_client
-
-    metadata.drop_all(engine)
 
 
 def _post_validate(client: TestClient, token: str) -> dict[str, object]:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Shared pytest fixtures for API tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, create_engine
+
+from app import create_app
+from app.api.access import rate_limiter
+from app.core.database import configure_engine
+from app.models import QrCode, QrStatus, metadata
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    """Provide a FastAPI test client backed by an in-memory database."""
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    metadata.create_all(engine)
+    configure_engine(engine)
+    rate_limiter.reset()
+
+    with Session(engine) as session:
+        session.add(QrCode(token="DEMO-NEW", status=QrStatus.NEW, product_id=1))
+        session.add(QrCode(token="DEMO-ACTIVE", status=QrStatus.ACTIVE, product_id=2))
+        session.add(QrCode(token="DEMO-BLOCKED", status=QrStatus.BLOCKED, product_id=3))
+        session.commit()
+
+    app = create_app()
+    with TestClient(app) as test_client:
+        yield test_client
+
+    metadata.drop_all(engine)

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,13 +1,20 @@
 const API_BASE = import.meta.env.VITE_API_BASE ?? '/api';
 
-export async function apiFetch<T>(endpoint: string, init: RequestInit = {}): Promise<T> {
-  const response = await fetch(`${API_BASE}${endpoint}`, {
+export async function apiFetch<T>(
+  endpoint: string,
+  init: RequestInit = {},
+  fetcher: typeof fetch = fetch
+): Promise<T> {
+  const response = await fetcher(`${API_BASE}${endpoint}`, {
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init.headers ?? {})
-    },
-    ...init
+    ...init,
+    headers:
+      init.headers instanceof Headers || Array.isArray(init.headers)
+        ? init.headers
+        : {
+            'Content-Type': 'application/json',
+            ...(init.headers ?? {})
+          }
   });
 
   if (!response.ok) {

--- a/apps/web/src/routes/access/+page.ts
+++ b/apps/web/src/routes/access/+page.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from '$lib/api';
 import type { PageLoad } from './$types';
 
 const DEMO_TOKENS = ['DEMO-ALPHA', 'DEMO-BETA', 'DEMO-GAMMA'] as const;
@@ -35,20 +36,17 @@ export const load: PageLoad = async ({ url, fetch }) => {
   }
 
   try {
-    const response = await fetch('/api/access/validate', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
+    const payload = await apiFetch<AccessValidation>(
+      '/access/validate',
+      {
+        method: 'POST',
+        body: JSON.stringify({ token })
       },
-      body: JSON.stringify({ token })
-    });
+      fetch
+    );
 
-    const payload = (await response.json()) as AccessValidation;
-
-    if (!response.ok || !payload?.status) {
-      const errorMessage = !response.ok
-        ? `HTTP ${response.status}`
-        : 'Unknown validation response';
+    if (!payload?.status) {
+      const errorMessage = 'Unknown validation response';
 
       return {
         token,


### PR DESCRIPTION
## Summary
- add an in-memory rate limiter and structured logging for access endpoints so SSR and client requests respect per-IP quotas
- implement `/api/access/register` and `/api/access/reregister` to create and migrate device bindings while enforcing cooldowns and reactivation limits
- refactor validation helpers and add comprehensive API tests covering registration flows, cooldown behaviour, rate limits, and logging

## Testing
- pytest apps/api/tests/api -q

------
https://chatgpt.com/codex/tasks/task_e_68cc6135c104832eab5e1442938eb399