### PR TITLE
Use relative API base for browser requests

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,7 @@
-const API_BASE = import.meta.env.VITE_API_BASE ?? '/api';
+import { browser } from '$app/environment';
+
+const SERVER_API_BASE = import.meta.env.VITE_API_BASE ?? '/api';
+const API_BASE = browser ? '/api' : SERVER_API_BASE;
 
 export async function apiFetch<T>(
   endpoint: string,


### PR DESCRIPTION
## Summary
- detect the browser runtime and use a relative `/api` base when fetching
- retain the absolute `VITE_API_BASE` for server-side requests so SSR can still reach the API

## Testing
- docker compose -f infra/docker-compose.yml up --build *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8323841c832e851a68eef03f3608